### PR TITLE
Fix url in cot.rb

### DIFF
--- a/cot.rb
+++ b/cot.rb
@@ -1,7 +1,7 @@
 class Cot < Formula
   desc "The command-line helper tool for CotEditor"
   homepage "https://coteditor.com/"
-  url "https://raw.githubusercontent.com/coteditor/cot/master/cot"
+  url "https://raw.githubusercontent.com/coteditor/cot/2.6.2/cot"
   version "2.6.2"
   sha256 "89741c526a88f7e43288e35a4c84d86e303c0b321a47b98b696a65a6fac95a7f"
 

--- a/cot.rb
+++ b/cot.rb
@@ -1,6 +1,7 @@
 class Cot < Formula
   desc "The command-line helper tool for CotEditor"
   homepage "https://coteditor.com/"
+  head "https://raw.githubusercontent.com/coteditor/cot/master/cot"
   url "https://raw.githubusercontent.com/coteditor/cot/2.6.2/cot"
   sha256 "89741c526a88f7e43288e35a4c84d86e303c0b321a47b98b696a65a6fac95a7f"
 

--- a/cot.rb
+++ b/cot.rb
@@ -2,7 +2,6 @@ class Cot < Formula
   desc "The command-line helper tool for CotEditor"
   homepage "https://coteditor.com/"
   url "https://raw.githubusercontent.com/coteditor/cot/2.6.2/cot"
-  version "2.6.2"
   sha256 "89741c526a88f7e43288e35a4c84d86e303c0b321a47b98b696a65a6fac95a7f"
 
   def install


### PR DESCRIPTION
Should fix https://github.com/coteditor/homebrew-coteditor/issues/1.

- Specify a pinned version for `url`
- Remove `version` and let Homebrew infer the version
- Add `haed` to install a version on `master` (we can use `--HEAD` option now)